### PR TITLE
Make sure that the keyframe always is at root level

### DIFF
--- a/_stratagem.scss
+++ b/_stratagem.scss
@@ -310,7 +310,9 @@ $animate-keyframes: ();
 
 @mixin animation($name, $opts: '') {
   @if not (map-has-key($animate-keyframes, $name)) {
-    @include keyframes($name);
+    @at-root (without: media) {
+      @include keyframes($name);
+    }
     $animate-keyframes: map-merge($animate-keyframes, ($name: '')) !global;
   }
   animation: #{$name} #{$opts};


### PR DESCRIPTION
This makes sure that the keyframe always compiles to the root level.
Had an issue when the keyframe was printed inside an `@media` and only worked in a specific browser width.
